### PR TITLE
Added single quote processing of object keys.

### DIFF
--- a/json5_parser/json5_parser_reader_template.h
+++ b/json5_parser/json5_parser_reader_template.h
@@ -507,7 +507,7 @@ namespace json5_parser
                     ;
 
                 pair_
-                    = (double_quoted_string_[ new_name ] | identifier_[ new_identifier ]) 
+                    = (single_quoted_string_[ new_name ] | double_quoted_string_[ new_name ] | identifier_[ new_identifier ]) 
                     >> ( ':' | eps_p[ &throw_not_colon ] )
                     >> ( value_ | eps_p[ &throw_not_value ] )
                     ;


### PR DESCRIPTION
JSON5 allows both sorts of quotes for object keys - see [https://spec.json5.org/#objects](https://spec.json5.org/#objects)